### PR TITLE
feat: auto-create PRs from issue-triggered Claude work

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,7 @@ on:
 permissions: {}
 
 jobs:
+  # Interactive mode: PR reviews and @claude mentions
   claude:
     if: >-
       (github.event_name == 'pull_request' &&
@@ -23,17 +24,16 @@ jobs:
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'issues' && github.event.action == 'labeled' &&
-        github.event.label.name == 'claude')
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      # write required for issue-triggered branch creation
       contents: write
       id-token: write
       pull-requests: write
       issues: write
+      actions: read
+      checks: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,4 +44,46 @@ jobs:
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+            checks: read
+
+  # Automation mode: issue-triggered work — implement, open PR, review, and notify
+  claude-issue:
+    if: >-
+      github.event_name == 'issues' && github.event.action == 'labeled' &&
+        github.event.label.name == 'claude'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      issues: write
+      actions: read
+      checks: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           label_trigger: "claude"
+          track_progress: "true"
+          additional_permissions: |
+            actions: read
+            checks: read
+          prompt: |
+            Implement a fix for issue #${{ github.event.issue.number }}.
+
+            After implementing:
+            1. Create a pull request with a clear title and description. Include "Closes #${{ github.event.issue.number }}" in the PR body.
+            2. Self-review your own PR — look for bugs, style issues, missed edge cases, and test gaps. If you find problems, push fixes.
+            3. Review all comments and review threads on the PR. For each one:
+               - If you can address the feedback, make the fix, push, and mark the conversation as resolved.
+               - If the comment requires human judgment, leave a reply explaining what you need.
+            4. Check CI status. If CI fails, read the logs, fix the issues, and push again. Repeat until CI passes.
+            5. When CI is green, all actionable review comments are resolved, and the PR is ready, leave a comment tagging @don-petry to review and merge.


### PR DESCRIPTION
## Summary

- **Split** the single `claude` job into two: `claude` (interactive) and `claude-issue` (automation)
- **`claude-issue`** runs when an issue is labeled `claude` and uses a `prompt` to drive the full lifecycle: implement → create PR → self-review → resolve comments → check CI → tag `@don-petry`
- **`claude`** keeps interactive mode for PR reviews and `@claude` mentions (unchanged behavior)
- Added `actions: read` and `checks: read` permissions to both jobs so Claude can monitor CI status and read workflow logs
- Enabled `track_progress` on the issue job for visibility

### Why

Issue #19 showed that the previous workflow created a branch but never opened a PR — Claude posted a "Create PR →" link and stopped. The compliance finding remained open across multiple audit cycles because no one clicked the link.

### What changes for each trigger

| Trigger | Before | After |
|---|---|---|
| Issue labeled `claude` | Branch + "Create PR" link | Full automation: PR created, self-reviewed, CI checked, maintainer tagged |
| PR opened/sync | Interactive review | Same (now with CI log access) |
| `@claude` on PR | Interactive response | Same (now with CI log access) |

## Test plan

- [ ] Label a test issue with `claude` and verify a PR is automatically created (not just a branch)
- [ ] Verify Claude self-reviews and resolves its own comments
- [ ] Verify Claude checks CI and tags `@don-petry` when green
- [ ] Verify `@claude` mentions on PRs still work in interactive mode
- [ ] Verify PR auto-review still triggers on opened/synchronize events

🤖 Generated with [Claude Code](https://claude.com/claude-code)