### PR TITLE
chore: add dependabot-rebase workflow (org standard)

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -1,0 +1,47 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-rebase.yml
+# Standard:        petry-projects/.github/standards/dependabot-policy.md
+# Reusable:        petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
+#     lives in the reusable workflow above.
+#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
+#     workflow version (bump SHA to latest main of petry-projects/.github).
+#   • You MUST NOT change: trigger event, the concurrency group name,
+#     the explicit secrets block, or the job-level `permissions:` block —
+#     reusable workflows can be granted no more permissions than the calling
+#     job has, so removing the stanza breaks
+#     the reusable's gh API calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Dependabot update-and-merge — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/dependabot-rebase.yml in your repo.
+# Required org/repo secrets (inherited):
+#   APP_ID         — GitHub App ID with contents:write and pull-requests:write
+#   APP_PRIVATE_KEY — GitHub App private key
+name: Dependabot update and merge
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # allow manual trigger to flush Dependabot PR queue
+
+concurrency:
+  group: dependabot-update-and-merge
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  dependabot-rebase:
+    permissions:
+      contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write  # re-approve PRs after branch update
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@9a694e5798ebb596476e6eda80f11e832d8fd0a9 # main
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Adds the org-standard `dependabot-rebase.yml` caller workflow. This repo has `dependabot-automerge.yml` (approves + enables auto-merge) but was missing the rebase/merge half of the pipeline.

The workflow serializes Dependabot PR merges: keeps branches up-to-date with main, re-approves after update-branch (to satisfy `require_last_push_approval`), and merges one at a time on each push to main.