### PR TITLE
fix(ci): pin claude-code-reusable.yml to SHA for action-pinning compliance

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,12 +31,14 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pins the reusable workflow reference from `@v1` to its commit SHA (`ee22b427cbce9ecadcf2b436acb57c3adf0cb63d`) to satisfy the org-level [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)
- Syncs the file with the current org template by adding the missing `check_run: types: [completed]` trigger event

## Test plan

- [ ] Compliance audit for `unpinned-actions-claude.yml` should pass after merge
- [ ] Claude Code workflow continues to trigger correctly on issue labels, PR events, and comments

Closes #84

Generated with [Claude Code](https://claude.ai/code)