### PR TITLE
fix(workflows): remove duplicate .github/ segment from reusable workflow paths

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/agent-shield.yml
 # Standard:        petry-projects/.github/standards/agent-standards.md
-# Reusable:        petry-projects/.github/.github/workflows/agent-shield-reusable.yml
+# Reusable:        petry-projects/.github/workflows/agent-shield-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. The AgentShield CLI scan and the
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
 # Standard:        petry-projects/.github/standards/dependabot-policy.md
-# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
+# Reusable:        petry-projects/.github/workflows/dependabot-automerge-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependabot-automerge-reusable.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Corrects `uses:` lines in `agent-shield.yml` and `dependabot-automerge.yml` to use `petry-projects/.github/workflows/` instead of the incorrect `petry-projects/.github/.github/workflows/`
- Updates matching comment headers for consistency
- Resolves the `reusable-workflow-path-duplicate-github` compliance finding reported by the weekly audit

## Details

The org compliance checker (`scripts/compliance-audit.sh`) flags the pattern `petry-projects/.github/.github/workflows/` in `uses:` lines as a duplicate-segment error. Both workflow files were copied verbatim from the org templates, which carry the same bug. The fix adapts the `uses:` path as directed by the compliance finding.

Files changed:
- `.github/workflows/agent-shield.yml` — `uses:` line and comment header
- `.github/workflows/dependabot-automerge.yml` — `uses:` line and comment header

Closes #122

---
Generated with [Claude Code](https://claude.ai/code)