### PR TITLE
fix(workflows): remove duplicate .github/ segment in reusable workflow paths

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/claude.yml
 # Standard:        petry-projects/.github/standards/ci-standards.md#4-claude-code-claudeyml
-# Reusable:        petry-projects/.github/.github/workflows/claude-code-reusable.yml
+# Reusable:        petry-projects/.github/workflows/claude-code-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All Claude Code logic, the prompt,
@@ -31,12 +31,14 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/workflows/claude-code-reusable.yml@v1
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependency-audit.yml
 # Standard:        petry-projects/.github/standards/ci-standards.md#5-dependency-audit-dependency-auditym
-# Reusable:        petry-projects/.github/.github/workflows/dependency-audit-reusable.yml
+# Reusable:        petry-projects/.github/workflows/dependency-audit-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All ecosystem-detection and audit logic
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependency-audit-reusable.yml@v1


### PR DESCRIPTION
## Summary

- Removes duplicate `.github/` path segment in `claude.yml` and `dependency-audit.yml` reusable workflow `uses:` references
- Changes `petry-projects/.github/.github/workflows/` → `petry-projects/.github/workflows/` per compliance check `reusable-workflow-path-duplicate-github`
- Adds missing `check_run: [completed]` trigger to `claude.yml`, aligning it with the canonical template in `petry-projects/.github/standards/workflows/claude.yml`

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm `dependency-audit / Detect ecosystems` required status check continues to fire
- [ ] Confirm Claude Code workflow triggers correctly on issue/PR events

Closes #123

Generated with [Claude Code](https://claude.ai/code)