### PR TITLE
chore: add bot accounts to CODEOWNERS for auto-merge support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all files
-* @don-petry
+* @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry


### PR DESCRIPTION
## Summary

Add \`@petry-projects-pr-review-agent\` and \`@dependabot-automerge-petry\` to CODEOWNERS so bot approvals satisfy the \`require_code_owner_review\` setting in the \`pr-quality\` ruleset.

## Why

Dependabot PRs were stuck at \`REVIEW_REQUIRED\` — the auto-merge bot was approving but isn't listed as a code owner. See [petry-projects/.github#180](https://github.com/petry-projects/.github/pull/180) for the org standard this implements.

## Test plan
- [ ] Confirm existing open Dependabot PRs unblock and auto-merge after this merges