### PR TITLE
chore: standardize CODEOWNERS on @petry-projects/org-leads

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,5 @@
-# Default owners for all files
-* @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
+# CODEOWNERS
+# Standard: use the @petry-projects/org-leads team for all code owner
+# assignments. See petry-projects/.github standards/codeowners-standard.md
+
+* @petry-projects/org-leads


### PR DESCRIPTION
Per the [org CODEOWNERS standard](https://github.com/petry-projects/.github/blob/main/standards/codeowners-standard.md), replace individual user/bot listings with the `@petry-projects/org-leads` team.

This unblocks repos with `require_code_owner_review: true` once the machine user `@donpetry-bot` is in the team.

Closes the CODEOWNERS gap from [pr-review-agent#27](https://github.com/don-petry/pr-review-agent/issues/27).