### PR TITLE
fix: pin pr-review-mention reusable to SHA d3d768d

### DIFF
--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -13,6 +13,8 @@
 #     so removing the stanza breaks the reusable's gh API calls.
 #   • If you need different behaviour, open a PR against the reusable in the
 #     central repo.
+#   • When publishing a new SHA of this reusable, also update this template and
+#     open a fanout PR across all caller repos.
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # PR Review Mention — thin caller for the org-level reusable.
@@ -34,5 +36,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@d3d768dabb7f28cc63283cdfe48630da53700e50 # main
     secrets: inherit


### PR DESCRIPTION
## Summary

Pin `.github/workflows/pr-review-mention.yml` to the correct SHA instead of `@v1`.

**Root cause:** The `v1` lightweight tag in `petry-projects/.github` pointed to commit `0cb4bba1` which predates the addition of `pr-review-mention-reusable.yml` (added in PR #237 on 2026-05-11). This caused a parse-time error in all caller repos:
```
error parsing called workflow: failed to fetch workflow: workflow was not found.
```

**Fix:** Pin to `d3d768dabb7f28cc63283cdfe48630da53700e50` (latest `main` commit containing the reusable workflow).

The `v1` tag has been force-moved to `d3d768d` and a new `v2` tag cut at the same SHA.

Ref: petry-projects/.github#267

Generated with [Claude Code](https://claude.ai/code)