### PR TITLE
feat(dev-lead): adopt dev-lead agent

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -1,0 +1,49 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Dev-Lead Agent — thin caller stub
+# Standard:  petry-projects/.github/standards/ci-standards.md#5-dev-lead-agent
+# Reusable:  petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml
+#
+# ADOPTING THIS WORKFLOW:
+#   1. Copy this file verbatim to .github/workflows/dev-lead.yml in your repo.
+#   2. Ensure CLAUDE_CODE_OAUTH_TOKEN is set as an org or repo secret.
+#   3. Optionally set GH_PAT_WORKFLOWS (required if Claude pushes workflow files).
+#   4. Optionally set vars.DEV_LEAD_ENGINE = "claude" | "gemini" | "copilot".
+#
+# UNLIKE claude.yml, this file has NO OIDC byte-for-byte constraint and may be
+# freely modified on PR branches to adjust triggers for repo-specific needs.
+#
+# REQUIRED secrets: CLAUDE_CODE_OAUTH_TOKEN
+# OPTIONAL secrets: GH_PAT_WORKFLOWS, GOOGLE_API_KEY, GH_PAT
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Dev-Lead Agent
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+  issues:
+    types: [labeled]
+  check_run:
+    types: [completed]
+  repository_dispatch:
+    types: [dev-lead-ci-failure]
+
+permissions: {}
+
+jobs:
+  dev-lead:
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main
+    secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+      checks: read


### PR DESCRIPTION
Adds the `dev-lead.yml` workflow from `petry-projects/.github/standards/workflows/dev-lead.yml`.

The dev-lead agent replaces the manual `@claude` invocation workflow with an automated, event-driven agent that handles CI failures, bot reviews, and human mentions.

Runs in parallel with `claude.yml` during the shadow period (~2026-05-29).

Part of Phase 8 rollout: petry-projects/.github-private#180