### PR TITLE
fix: pin dependabot-rebase.yml to reusable @v1 (compliance)

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -6,20 +6,22 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
 #     lives in the reusable workflow above.
-#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
-#     workflow version (bump SHA to latest main of petry-projects/.github).
-#   • You MUST NOT change: trigger event, the concurrency group name,
-#     the explicit secrets block, or the job-level `permissions:` block —
-#     reusable workflows can be granted no more permissions than the calling
-#     job has, so removing the stanza breaks
-#     the reusable's gh API calls.
+#   • You MAY change: the ref in the `uses:` line when upgrading the reusable
+#     workflow version (bump to latest commit SHA or tag of petry-projects/.github).
+#   • You MUST NOT change: the concurrency group name, the explicit secrets
+#     block, or the job-level `permissions:` block — reusable workflows can be
+#     granted no more permissions than the calling job has, so removing the
+#     stanza breaks the reusable's gh API calls. Do not remove any trigger
+#     (`push` keeps the self-sustaining chain; `schedule` is the safety net
+#     when no PR merges have occurred recently; `workflow_dispatch` allows
+#     manual queue flushes).
 #   • If you need different behaviour, open a PR against the reusable in the
 #     central repo.
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # Dependabot update-and-merge — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/dependabot-rebase.yml in your repo.
-# Required org/repo secrets (inherited):
+# Required org secrets (passed explicitly):
 #   APP_ID         — GitHub App ID with contents:write and pull-requests:write
 #   APP_PRIVATE_KEY — GitHub App private key
 name: Dependabot update and merge
@@ -28,6 +30,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 */4 * * *' # every 4 hours — safety net when no pushes to main trigger the chain
   workflow_dispatch: # allow manual trigger to flush Dependabot PR queue
 
 concurrency:
@@ -39,9 +43,8 @@ permissions: {}
 jobs:
   dependabot-rebase:
     permissions:
-      contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
-      pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@9a694e5798ebb596476e6eda80f11e832d8fd0a9 # main
+      pull-requests: write # call update-branch API on behind PRs and merge when ready
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@b51e2edf830ea085be0277bcf3174c7b3ec8f958 # v1
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Replaces `dependabot-rebase.yml` with the verbatim canonical stub from `petry-projects/.github/standards/workflows/dependabot-rebase.yml`
- Pins the reusable workflow reference to `@b51e2edf830ea085be0277bcf3174c7b3ec8f958 # v1` (was pinned to `main` SHA)
- Adds the scheduled safety-net trigger (`0 */4 * * *`) that was missing
- Removes the unnecessary `contents: write` permission (reusable only needs `pull-requests: write`)

## Compliance

This resolves the `non-stub-dependabot-rebase.yml` compliance finding — the `uses:` line now references `@v1` per the org standard.

Closes #144

---
Generated with [Claude Code](https://claude.ai/code)