### PR TITLE
fix: add CodeRabbit (347564) to check-suite auto-trigger disable list

### DIFF
--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -23,15 +23,17 @@ fi
 echo "Applying repository settings to ${REPO}..."
 
 # ── Check-suite auto-trigger ──────────────────────────────────────────────────
-# The Claude GitHub App (ID 1236702) auto-trigger creates a queued check suite
-# on every push.  That suite is never completed, permanently blocking auto-merge.
-# Disable it so GitHub stops enqueuing phantom check suites for this app.
+# Two GitHub Apps create orphaned "queued" check suites on every push that are
+# never completed, permanently blocking auto-merge. Disable auto-trigger for both:
+#   1236702 = Claude (anthropics/claude-code-action)
+#   347564  = CodeRabbit
+# See: standards/github-settings.md#check-suite-auto-trigger
 gh api \
   --method PATCH \
   --header "Accept: application/vnd.github+json" \
   "/repos/${REPO}/check-suites/preferences" \
   --input - <<'JSON'
-{"auto_trigger_checks":[{"app_id":1236702,"setting":false}]}
+{"auto_trigger_checks":[{"app_id":1236702,"setting":false},{"app_id":347564,"setting":false}]}
 JSON
 
-echo "Done: disabled check-suite auto-trigger for Claude app (1236702) on ${REPO}."
+echo "Done: disabled check-suite auto-trigger for Claude (1236702) and CodeRabbit (347564) on ${REPO}."


### PR DESCRIPTION
## Summary

- The compliance audit has been repeatedly flagging that CodeRabbit (app_id `347564`) auto-trigger is enabled, permanently blocking auto-merge
- Root cause: `scripts/apply-repo-settings.sh` only disabled app `1236702` (Claude) but the [org standard](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md) requires **both** `1236702` (Claude) and `347564` (CodeRabbit) to have `auto_trigger_checks: false`
- Previous direct API fixes didn't persist because re-running the script only applied the Claude setting, leaving CodeRabbit re-enabled
- Fix: add `{"app_id":347564,"setting":false}` to the PATCH payload so both apps are disabled in one call

## Test plan

- [ ] `bash scripts/apply-repo-settings.sh bmad-bgreat-suite` — verify it disables both app IDs without error
- [ ] Next compliance audit run should report no finding for `check-suite-auto-trigger-347564`

Closes #140

Generated with [Claude Code](https://claude.ai/code)