### PR TITLE
fix: correct pr-auto-review reusable workflow reference

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -49,6 +49,6 @@ jobs:
       pull-requests: read
       checks: read
       actions: read
-    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310 # v2
+    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@v2 # v2
     secrets:
       GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}

--- a/.gitignore
+++ b/.gitignore
@@ -524,3 +524,4 @@ _bmad-output/
 .dev-lead/
 .dev-lead/
 .dev-lead/
+.dev-lead/


### PR DESCRIPTION
Update pr-auto-review.yml to use @v2 tag for the reusable workflow.