### PR TITLE
fix(dev-lead): grant statuses:read (fixes startup_failure)

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -47,3 +47,4 @@ jobs:
       issues: write
       actions: read
       checks: read
+      statuses: read   # required by dev-lead-reusable.yml since #435


### PR DESCRIPTION
The reusable workflow has requested `statuses: read` at the job level since #435, but this caller never granted it. A reusable workflow can't request more than its caller grants, so runs fail with `startup_failure` (**6 recent runs**). Adds `statuses: read` to `jobs.dev-lead.permissions`.

**Urgent:** should merge before the org re-sweep at 2026-06-07 04:30 UTC, which will re-comment @dev-lead on stuck PRs (#247, #205, #272, #204, #245, #269).

Part of the dev-lead stub alignment. Refs petry-projects/.github#402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)