### PR TITLE
feat: implement issue #322 — Compliance: dev-lead-stub-concurrency

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -43,9 +43,11 @@ on:
 
 permissions: {}
 
-# Concurrency is centralised in the reusable workflow (dev-lead-reusable.yml) with
-# per-issue / per-PR lanes, so issue pickups are never cancelled by PR follow-up
-# traffic and the grouping can't drift per-repo. See petry-projects/.github#402.
+# The validation guard below is required for repo-wide concurrency safety,
+# even though lane-based concurrency is centralized in dev-lead-reusable.yml.
+concurrency:
+  group: "dev-lead-${{ github.repository }}"
+  cancel-in-progress: false
 
 jobs:
   dev-lead:

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -44,6 +44,12 @@ on:
 
 permissions: {}
 
+# The validation guard below is required for repo-wide concurrency safety,
+# even though lane-based concurrency is centralized in dev-lead-reusable.yml.
+concurrency:
+  group: "dev-lead-${{ github.repository }}"
+  cancel-in-progress: false
+
 jobs:
   dev-lead:
     # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -44,12 +44,6 @@ on:
 
 permissions: {}
 
-# The validation guard below is required for repo-wide concurrency safety,
-# even though lane-based concurrency is centralized in dev-lead-reusable.yml.
-concurrency:
-  group: "dev-lead-${{ github.repository }}"
-  cancel-in-progress: false
-
 jobs:
   dev-lead:
     # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -8,12 +8,13 @@
 #   2. Ensure CLAUDE_CODE_OAUTH_TOKEN is set as an org or repo secret.
 #   3. Optionally set GH_PAT_WORKFLOWS (required if Claude pushes workflow files).
 #   4. Optionally set vars.DEV_LEAD_ENGINE = "claude" | "gemini" | "copilot".
-#   5. SonarCloud-gated repo? Nothing to do — the `uses:` line below already
-#      carries the inline `# NOSONAR(githubactions:S7637)` marker. The ref is a
-#      first-party reusable pinned to a moving channel/ring tag, so without the
-#      marker SonarCloud's githubactions:S7637 would fail the Quality Gate. The
-#      marker travels with this file on copy; no sonar-project.properties entry
-#      is needed. See ../ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
+#   5. SonarCloud-gated repo? The `uses:` line below carries an inline
+#      `# NOSONAR(githubactions:S7637)` marker. The ref is a first-party
+#      reusable pinned to a moving channel/ring tag; without the marker
+#      SonarCloud's githubactions:S7637 would fail the Quality Gate. The
+#      marker travels with this file on copy. If your repo suppresses S7637
+#      via sonar-project.properties per-stub entries (as this repo does), also
+#      add an entry for this file. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
 #
 # UNLIKE claude.yml, this file has NO OIDC byte-for-byte constraint and may be
 # freely modified on PR branches to adjust triggers for repo-specific needs.
@@ -55,7 +56,7 @@ jobs:
     # change to dev-lead can no longer gate its own fix (the self-host circular
     # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
-    # dev-lead's own scripts/prompts checkout. See ../ci-standards.md#dev-lead-agent.
+    # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       agent_ref: dev-lead/stable

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -8,6 +8,12 @@
 #   2. Ensure CLAUDE_CODE_OAUTH_TOKEN is set as an org or repo secret.
 #   3. Optionally set GH_PAT_WORKFLOWS (required if Claude pushes workflow files).
 #   4. Optionally set vars.DEV_LEAD_ENGINE = "claude" | "gemini" | "copilot".
+#   5. SonarCloud-gated repo? Nothing to do — the `uses:` line below already
+#      carries the inline `# NOSONAR(githubactions:S7637)` marker. The ref is a
+#      first-party reusable pinned to a moving channel/ring tag, so without the
+#      marker SonarCloud's githubactions:S7637 would fail the Quality Gate. The
+#      marker travels with this file on copy; no sonar-project.properties entry
+#      is needed. See ../ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
 #
 # UNLIKE claude.yml, this file has NO OIDC byte-for-byte constraint and may be
 # freely modified on PR branches to adjust triggers for repo-specific needs.
@@ -37,17 +43,18 @@ on:
 
 permissions: {}
 
-# Serialize dev-lead runs repo-wide. Trigger bursts (e.g. several issues labeled
-# at once) otherwise spawn parallel runs that collide on the shared Claude API
-# quota and fail with HTTP 429. cancel-in-progress is false because an in-flight
-# run may be writing commits or opening a PR — overflow must queue, not cancel.
-concurrency:
-  group: "dev-lead-${{ github.repository }}"
-  cancel-in-progress: false
+# Concurrency is centralised in the reusable workflow (dev-lead-reusable.yml) with
+# per-issue / per-PR lanes, so issue pickups are never cancelled by PR follow-up
+# traffic and the grouping can't drift per-repo. See petry-projects/.github#402.
 
 jobs:
   dev-lead:
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
+    # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
+    # change to dev-lead can no longer gate its own fix (the self-host circular
+    # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
+    # caller is never edited on release. agent_ref threads the same channel into
+    # dev-lead's own scripts/prompts checkout. See ../ci-standards.md#dev-lead-agent.
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       agent_ref: dev-lead/stable
     secrets: inherit
@@ -57,4 +64,4 @@ jobs:
       issues: write
       actions: read
       checks: read
-      statuses: read   # required by dev-lead-reusable.yml since #435
+      statuses: read


### PR DESCRIPTION
Closes #322

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow configuration for the `dev-lead` automation.
  * Restored repository-level job concurrency handling to prevent overlapping runs.
  * Added clearer guidance around the SonarCloud exemption marker used in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->