### PR TITLE
chore: sync 8 org-standard workflow stub(s) from petry-projects/.github

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,9 +16,10 @@
 #   • If you need different behaviour, open a PR against the reusable.
 # ─────────────────────────────────────────────────────────────────────────────
 #
-# Auto-add this repo's qualifying issues, PRs, and Ideas-category discussions
-# to the org-level Initiatives project
-# (https://github.com/orgs/petry-projects/projects/1).
+# Track this repo's issues (all, un-gated) and dev-lead-labeled PRs on the
+# org-level Initiatives project
+# (https://github.com/orgs/petry-projects/projects/1). Ideas live in
+# Discussions and are not tracked here.
 #
 # To adopt: copy this file to .github/workflows/add-to-project.yml in your
 # repo. Requires the org secrets INITIATIVES_APP_ID and
@@ -26,7 +27,6 @@
 # app installation must include this repo. See petry-projects/.github#387.
 #
 # Tracking: petry-projects/.github#387, #415
-# Discussion: petry-projects/.github#386
 name: Auto-add to Initiatives project
 
 on:
@@ -34,16 +34,12 @@ on:
     types: [opened, labeled, unlabeled, reopened]
   pull_request_target:
     types: [opened, labeled, unlabeled, reopened, ready_for_review]
-  discussion:
-    types: [created, category_changed, deleted, transferred]
 
 permissions: {}
 
 concurrency:
   group: >-
-    add-to-project-${{ github.event_name == 'discussion'
-    && format('disc-{0}', github.event.discussion.number)
-    || format('{0}-{1}', github.event_name,
+    add-to-project-${{ format('{0}-{1}', github.event_name,
        github.event.issue.number || github.event.pull_request.number) }}
   cancel-in-progress: false
 
@@ -51,7 +47,7 @@ jobs:
   add-to-project:
     permissions:
       contents: read
-    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1

--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/ring1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -50,5 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/ring1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/ring1
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -50,7 +50,7 @@ jobs:
     permissions:
       contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/ring1
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,6 +1,6 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependency-audit.yml
-# Standard:        petry-projects/.github/standards/ci-standards.md#5-dependency-audit-dependency-auditym
+# Standard:        petry-projects/.github/standards/ci-standards.md#7-dependency-audit-dependency-audityml
 # Reusable:        petry-projects/.github/.github/workflows/dependency-audit-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/ring1
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -8,9 +8,22 @@
 #   2. Ensure CLAUDE_CODE_OAUTH_TOKEN is set as an org or repo secret.
 #   3. Optionally set GH_PAT_WORKFLOWS (required if Claude pushes workflow files).
 #   4. Optionally set vars.DEV_LEAD_ENGINE = "claude" | "gemini" | "copilot".
+#   5. SonarCloud-gated repo? Nothing to do — the `uses:` line below already
+#      carries the inline `# NOSONAR(githubactions:S7637)` marker. The ref is a
+#      first-party reusable pinned to a moving channel/ring tag, so without the
+#      marker SonarCloud's githubactions:S7637 would fail the Quality Gate. The
+#      marker travels with this file on copy; no sonar-project.properties entry
+#      is needed. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
 #
-# UNLIKE claude.yml, this file has NO OIDC byte-for-byte constraint and may be
-# freely modified on PR branches to adjust triggers for repo-specific needs.
+# This stub is copied VERBATIM and is full-file identical across every adopting
+# repo, modulo the per-repo ring/channel pin on the `uses:` ref and its matching
+# `agent_ref` (below). Any other diff is drift, not a repo-specific liberty:
+# `on:`, `permissions:`, and `concurrency:` are NOT repo-adjustable — do not trim
+# a trigger, narrow a permission, or add a concurrency block on a PR branch. The
+# behavior lives in the reusable, so change it there (or via a standards PR) and
+# let the channel tag promote it centrally — never by editing this caller. See
+# https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#centralization-tiers and
+# https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#reusable-workflow-versioning--the-stable-channel.
 #
 # REQUIRED secrets: CLAUDE_CODE_OAUTH_TOKEN
 # OPTIONAL secrets: GH_PAT_WORKFLOWS, GOOGLE_API_KEY, GH_PAT
@@ -37,19 +50,20 @@ on:
 
 permissions: {}
 
-# Serialize dev-lead runs repo-wide. Trigger bursts (e.g. several issues labeled
-# at once) otherwise spawn parallel runs that collide on the shared Claude API
-# quota and fail with HTTP 429. cancel-in-progress is false because an in-flight
-# run may be writing commits or opening a PR — overflow must queue, not cancel.
-concurrency:
-  group: "dev-lead-${{ github.repository }}"
-  cancel-in-progress: false
+# Concurrency is centralised in the reusable workflow (dev-lead-reusable.yml) with
+# per-issue / per-PR lanes, so issue pickups are never cancelled by PR follow-up
+# traffic and the grouping can't drift per-repo. See petry-projects/.github#402.
 
 jobs:
   dev-lead:
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
+    # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
+    # change to dev-lead can no longer gate its own fix (the self-host circular
+    # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
+    # caller is never edited on release. agent_ref threads the same channel into
+    # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      agent_ref: dev-lead/stable
+      agent_ref: dev-lead/v1-ring1
     secrets: inherit
     permissions:
       contents: write
@@ -57,4 +71,4 @@ jobs:
       issues: write
       actions: read
       checks: read
-      statuses: read   # required by dev-lead-reusable.yml since #435
+      statuses: read

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -37,5 +37,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable  # NOSONAR(githubactions:S7637) first-party channel ref  # zizmor: ignore[unpinned-uses]
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/tools/test-dev-lead-concurrency.sh
+++ b/tools/test-dev-lead-concurrency.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Validates that .github/workflows/dev-lead.yml declares a concurrency block so
-# bursts of triggering events serialize instead of running in parallel and
-# exhausting the shared Claude API quota (HTTP 429), which was the root cause of
-# the dev-lead workflow's degraded failure rate (issue #308).
+# Validates that .github/workflows/dev-lead.yml does NOT declare a top-level
+# concurrency block. Since petry-projects/.github#402, concurrency is centralised
+# in the reusable workflow (dev-lead-reusable.yml) with per-issue / per-PR lanes.
+# A local concurrency block in the caller would override the reusable's lanes and
+# re-introduce the serialisation problems fixed by #402.
 set -euo pipefail
 
 ERRORS=0
@@ -31,9 +32,11 @@ if ! python3 -c "import yaml" > /dev/null 2>&1; then
   exit 1
 fi
 
-# Check 1: the workflow parses as valid YAML and declares a top-level
-# concurrency block with a non-empty group and cancel-in-progress: false.
-echo "Check 1: top-level concurrency block with group and cancel-in-progress: false"
+# Check 1: the workflow parses as valid YAML and does NOT declare a top-level
+# concurrency block. Since petry-projects/.github#402, concurrency lives in the
+# reusable workflow. A caller-level block would override the reusable's per-lane
+# grouping and re-introduce API-quota exhaustion (HTTP 429).
+echo "Check 1: no top-level concurrency block (concurrency is in the reusable)"
 if python3 - "$WORKFLOW" << 'PY'; then
 import sys
 import yaml
@@ -50,28 +53,17 @@ if not isinstance(doc, dict):
     sys.exit(1)
 
 concurrency = doc.get("concurrency")
-if concurrency is None:
-    print("no top-level 'concurrency:' key", file=sys.stderr)
-    sys.exit(1)
-
-if not isinstance(concurrency, dict):
-    print("'concurrency:' must be a mapping with group/cancel-in-progress", file=sys.stderr)
-    sys.exit(1)
-
-group = concurrency.get("group")
-if not isinstance(group, str) or not group.strip():
-    print("'concurrency.group' must be a non-empty string", file=sys.stderr)
-    sys.exit(1)
-
-# In-flight dev-lead runs write commits and open PRs; cancelling them mid-run
-# would strand partial work. Overflow must queue, not cancel.
-if concurrency.get("cancel-in-progress") is not False:
-    print("'concurrency.cancel-in-progress' must be false", file=sys.stderr)
+if concurrency is not None:
+    print(
+        "top-level 'concurrency:' key found — remove it; concurrency is "
+        "centralised in the reusable workflow (petry-projects/.github#402)",
+        file=sys.stderr,
+    )
     sys.exit(1)
 PY
   echo "  done."
 else
-  error "dev-lead.yml concurrency block missing or malformed"
+  error "dev-lead.yml has a top-level concurrency block that must be removed"
 fi
 
 echo ""


### PR DESCRIPTION
Syncs the following org-standard workflow stub(s) from `petry-projects/.github` (`standards/workflows/`), deployed verbatim:

- `pr-review-mention.yml`
- `dev-lead.yml`
- `agent-shield.yml`
- `auto-rebase.yml`
- `dependabot-automerge.yml`
- `dependabot-rebase.yml`
- `dependency-audit.yml`
- `add-to-project.yml`

Opened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.