### PR TITLE
chore: major-scope repin self-consumer stubs [#657 F5]

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -47,7 +47,7 @@ jobs:
   add-to-project:
     permissions:
       contents: read
-    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1

--- a/.github/workflows/ci-failure-analyst.yml
+++ b/.github/workflows/ci-failure-analyst.yml
@@ -75,6 +75,6 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       !startsWith(github.event.workflow_run.name, 'CI Failure Analyst')
-    uses: petry-projects/.github-private/.github/workflows/ci-failure-analyst-reusable.yml@ci-failure-analyst/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github-private/.github/workflows/ci-failure-analyst-reusable.yml@ci-failure-analyst/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -143,7 +143,7 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       # Populated by the `redispatch` bridge above (which forwards the new
       # Discussion number on `discussion: created`); empty on schedule/dispatch →

--- a/.github/workflows/idea-triage.yml
+++ b/.github/workflows/idea-triage.yml
@@ -42,5 +42,5 @@ permissions: {}
 
 jobs:
   idea-triage:
-    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/.github/workflows/initiative-planner.yml
+++ b/.github/workflows/initiative-planner.yml
@@ -44,5 +44,5 @@ permissions: {}
 
 jobs:
   initiative-planner:
-    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -60,6 +60,6 @@ jobs:
       pull-requests: read
       checks: read
       actions: read
-    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@pr-auto-review/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@pr-auto-review/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**,.github/workflows/pr-review
 # file individually; ci.yml / sonarcloud.yml and any third-party `uses:` keep
 # full SHA-pin enforcement — do NOT replace these with a blanket
 # `workflows/*.yml` resourceKey.
-sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreviewmention,s7637_prautoreview,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_addtoproject,s7637_devlead,s7637_initiativeplanner,s7637_initiativetriage,s7637_featureideation,s7635_initiativeplanner,s7635_initiativetriage
+sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreviewmention,s7637_prautoreview,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_addtoproject,s7637_devlead,s7637_initiativeplanner,s7637_initiativetriage,s7637_featureideation,s7635_initiativeplanner,s7635_initiativetriage,s7637_cifailureanalyst,s7637_ideatriage
 
 sonar.issue.ignore.multicriteria.s7637_agentshield.ruleKey=githubactions:S7637
 sonar.issue.ignore.multicriteria.s7637_agentshield.resourceKey=**/.github/workflows/agent-shield.yml
@@ -61,3 +61,7 @@ sonar.issue.ignore.multicriteria.s7635_initiativeplanner.resourceKey=**/.github/
 
 sonar.issue.ignore.multicriteria.s7635_initiativetriage.ruleKey=githubactions:S7635
 sonar.issue.ignore.multicriteria.s7635_initiativetriage.resourceKey=**/.github/workflows/idea-triage.yml
+sonar.issue.ignore.multicriteria.s7637_cifailureanalyst.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_cifailureanalyst.resourceKey=**/ci-failure-analyst.yml
+sonar.issue.ignore.multicriteria.s7637_ideatriage.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_ideatriage.resourceKey=**/idea-triage.yml


### PR DESCRIPTION
Re-pins meta-repo caller stubs bare @<agent>/<tier> -> @<agent>/v<M>-<tier> (deploy tool exempts meta-repos; needed so the inner-ring canary flow doesn't freeze once the engine promotes v-lines, and to unblock the guarded bare-tag retirement). Completes the #657 F5 live migration. NOSONAR markers preserved.