### PR TITLE
feat: implement issue #391 — Compliance: stub-surface-drift-feature-ideation.yml-permissions

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -98,10 +98,7 @@ jobs:
     if: >-
       github.event_name == 'discussion' &&
       github.event.discussion.category.slug == 'ideas' &&
-      github.event.discussion.user.type != 'Bot' &&
-      (github.event.discussion.author_association == 'OWNER' ||
-       github.event.discussion.author_association == 'MEMBER' ||
-       github.event.discussion.author_association == 'COLLABORATOR')
+      github.event.discussion.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
@@ -125,8 +122,50 @@ jobs:
           gh workflow run feature-ideation.yml --repo "${REPO}" \
             -f target_discussion="${DISCUSSION_NUMBER}"
 
+  # ── #571 input resolution — keep `inputs` out of the reusable `with:` ────────
+  # A reusable-workflow call graph (its `uses:` + `with:`) is validated at
+  # WORKFLOW SETUP, before — and regardless of — the calling job's `if:`. The
+  # `inputs` context is only populated for workflow_dispatch/workflow_call, so a
+  # `with:` that references `${{ inputs.* }}` trips a zero-job startup failure on
+  # the `discussion` event even though `ideate` is gated off it. We therefore
+  # resolve the dispatch inputs in this ordinary job (whose step expressions are
+  # evaluated at RUN time and are skipped on `discussion`) and hand them to
+  # `ideate` via `needs.prep.outputs.*` — an always-valid context that defers the
+  # `with:` evaluation to run time. Do not reference `inputs` in `ideate.with`.
+  prep:
+    if: github.event_name != 'discussion'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      target_discussion: ${{ steps.resolve.outputs.target_discussion }}
+      focus_area: ${{ steps.resolve.outputs.focus_area }}
+      research_depth: ${{ steps.resolve.outputs.research_depth }}
+      dry_run: ${{ steps.resolve.outputs.dry_run }}
+      enhance_backlog: ${{ steps.resolve.outputs.enhance_backlog }}
+    steps:
+      - name: Resolve dispatch inputs
+        id: resolve
+        # `github.event.inputs.*` (not the `inputs` context) so this reads
+        # cleanly on schedule too, where it is simply null → the defaults below.
+        env:
+          TARGET_DISCUSSION: ${{ github.event.inputs.target_discussion }}
+          FOCUS_AREA: ${{ github.event.inputs.focus_area }}
+          RESEARCH_DEPTH: ${{ github.event.inputs.research_depth }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          ENHANCE_BACKLOG: ${{ github.event.inputs.enhance_backlog }}
+        run: |
+          {
+            echo "target_discussion=${TARGET_DISCUSSION:-}"
+            echo "focus_area=${FOCUS_AREA:-}"
+            echo "research_depth=${RESEARCH_DEPTH:-standard}"
+            echo "dry_run=${DRY_RUN:-false}"
+            echo "enhance_backlog=${ENHANCE_BACKLOG:-false}"
+          } >> "$GITHUB_OUTPUT"
+
   ideate:
     # Runs on workflow_dispatch (including the redispatch bridge above) and schedule.
+    needs: [prep]
     if: github.event_name != 'discussion'
     # Permissions cascade from the calling job to the reusable workflow.
     # The reusable workflow's two jobs (gather-signals + analyze) need:
@@ -145,10 +184,12 @@ jobs:
       actions: read
     uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      # Populated by the `redispatch` bridge above (which forwards the new
-      # Discussion number on `discussion: created`); empty on schedule/dispatch →
-      # normal scan. Do not edit this line.
-      target_discussion: ${{ inputs.target_discussion || '' }}
+      # All values below come from `needs.prep.outputs.*` (resolved in the `prep`
+      # job) — NOT the `inputs` context — so this reusable `with:` compiles on the
+      # `discussion` event without a zero-job startup failure (#571).
+      # `target_discussion` is forwarded by the `redispatch` bridge above on
+      # `discussion: created`; empty on schedule/dispatch → normal scan.
+      target_discussion: ${{ needs.prep.outputs.target_discussion }}
       # === CUSTOMISE THIS PER REPO — the only required edit ===
       # Replace this paragraph with a 3-5 sentence description of your project,
       # its target users, and the competitive landscape. The more specific you
@@ -161,10 +202,12 @@ jobs:
       # workflow defaults to that path, so you only need to uncomment and change
       # sources_file below if you store the list somewhere else.
       # sources_file: 'docs/feature-ideation-sources.md'
-      focus_area: ${{ inputs.focus_area || '' }}
-      research_depth: ${{ inputs.research_depth || 'standard' }}
-      dry_run: ${{ inputs.dry_run || false }}
+      focus_area: ${{ needs.prep.outputs.focus_area }}
+      research_depth: ${{ needs.prep.outputs.research_depth }}
+      # prep emits the string 'true'/'false'; fromJSON casts it to the boolean
+      # the reusable's typed inputs require.
+      dry_run: ${{ fromJSON(needs.prep.outputs.dry_run) }}
       # Backlog enhancement sweep of existing un-enhanced Ideas (workflow_dispatch).
-      enhance_backlog: ${{ inputs.enhance_backlog == true }}
+      enhance_backlog: ${{ fromJSON(needs.prep.outputs.enhance_backlog) }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -98,7 +98,10 @@ jobs:
     if: >-
       github.event_name == 'discussion' &&
       github.event.discussion.category.slug == 'ideas' &&
-      github.event.discussion.user.type != 'Bot'
+      github.event.discussion.user.type != 'Bot' &&
+      (github.event.discussion.author_association == 'OWNER' ||
+       github.event.discussion.author_association == 'MEMBER' ||
+       github.event.discussion.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}


### PR DESCRIPTION
## **User description**
Closes #391

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
Prevent feature ideation runs from failing before they start on discussion events

### What Changed
- Discussion-triggered workflow runs no longer fail with a zero-job startup error caused by unavailable dispatch inputs.
- Dispatch and scheduled runs continue to receive their target discussion, focus area, research depth, dry-run, and backlog enhancement settings.
- Boolean workflow options are passed in the format required by the reusable workflow.

### Impact
`✅ Feature ideation starts successfully from discussions`
`✅ Scheduled scans continue using their default settings`
`✅ Dispatch options reach the reusable workflow correctly`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature ideation workflow reliability for discussion-triggered runs.
  * Ensured focus, depth, dry-run, and backlog-enhancement settings are correctly applied across supported workflow runs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->