### PR TITLE
chore: insert org secrets baseline in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# >>> BEGIN petry-projects secrets baseline (managed by .github — do not edit) >>>
 # ============================================================================
 # petry-projects baseline .gitignore — SECRETS ONLY
 # ----------------------------------------------------------------------------
@@ -377,7 +378,7 @@ private.yml
 .earthly/config.yml
 
 # ---------------------------------------------------------------------------
-# 13. Agent / local worktrees (org coding policy)
+# 13. Agent / local worktrees and CI-generated tool artifacts (org coding policy)
 # ---------------------------------------------------------------------------
 # Temporary worktrees created by Claude Code and other agents. Not strictly
 # secret material, but the petry-projects coding guidelines require these
@@ -385,14 +386,22 @@ private.yml
 # be committed accidentally.
 .claude/worktrees/
 .worktrees/
+.dev-lead/
+# CI downloads actionlint into the repo root during linting; ignore the
+# generated binary so local lint runs cannot accidentally commit it.
+actionlint
+actionlint.tar.gz
 
 # ============================================================================
 # End of petry-projects secrets baseline
 # ============================================================================
+# <<< END petry-projects secrets baseline <<<
+#
+#
 
-# ---------------------------------------------------------------------------
+# 13. Agent / local worktrees (org coding policy)
+
 # bmad-bgreat-suite repo-specific entries
-# ---------------------------------------------------------------------------
 node_modules/
 .DS_Store
 *.log
@@ -400,4 +409,3 @@ _bmad/
 _bmad-output/
 .claude/skills/
 .cursor/skills/
-.dev-lead/

--- a/.gitignore
+++ b/.gitignore
@@ -396,10 +396,6 @@ actionlint.tar.gz
 # End of petry-projects secrets baseline
 # ============================================================================
 # <<< END petry-projects secrets baseline <<<
-#
-#
-
-# 13. Agent / local worktrees (org coding policy)
 
 # bmad-bgreat-suite repo-specific entries
 node_modules/


### PR DESCRIPTION
Syncs the marker-wrapped org secrets baseline (L1) into \`.gitignore\` (INSERT), preserving this repo's per-repo L2 entries below the END marker. Opened by `scripts/sync-gitignore-baseline.sh` — see `standards/gitignore-standard.md`. Labeled `gitignore-baseline` and left for the normal review/auto-merge pipeline; the sweep never merges directly.