### PR TITLE
fix: correct broken dev-lead pin (@dev-lead/v14-ring1 → v1-ring1)

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -56,14 +56,14 @@ permissions: {}
 
 jobs:
   dev-lead:
-    # Pinned to the moving dev-lead/v1-stable channel tag, not @main, so a broken
+    # Pinned to the moving dev-lead/v1-ring1 channel tag, not @main, so a broken
     # change to dev-lead can no longer gate its own fix (the self-host circular
-    # dependency). Promotion is done by moving the dev-lead/v1-stable tag centrally; this
+    # dependency). Promotion is done by moving the dev-lead/v1-ring1 tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
     # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v14-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      agent_ref: dev-lead/v14-ring1
+      agent_ref: dev-lead/v1-ring1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## **User description**
Incident fix for the regression in #870. bmad#409 deployed `@dev-lead/v14-ring1`, a channel tag that does not exist (dev-lead's only v-form channels are `dev-lead/v1-*`), breaking bmad's dev-lead workflow. Corrects the `uses:`/`agent_ref` (and the aligned comment) to the existing, tier-correct `dev-lead/v1-ring1`. Restores function AND lands the correct convergence pin. Root driver bug tracked in #870.


___

## **CodeAnt-AI Description**
**Restore the dev-lead workflow by pointing it to the existing ring1 channel**

### What Changed
- The dev-lead workflow now uses the valid `v1-ring1` channel instead of the broken `v14-ring1` one
- The matching agent reference and comment were updated to the same channel so the workflow stays aligned

### Impact
`✅ Restored dev-lead runs`
`✅ Fewer workflow failures from invalid channel pins`
`✅ Correct routing to the intended dev-lead release channel`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development workflow to use the current development channel.
  * Synchronized the workflow’s agent reference and related configuration comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->